### PR TITLE
Attributes are normalized twice in parse method

### DIFF
--- a/lib/xmpp4r/streamparser.rb
+++ b/lib/xmpp4r/streamparser.rb
@@ -40,7 +40,19 @@ module Jabber
 
         parser.listen( :start_element ) do |uri, localname, qname, attributes|
           e = REXML::Element.new(qname)
-          e.add_attributes attributes
+          if attributes.kind_of? Hash
+            unnormalized_attributes = {}
+            attributes.each_pair do |key, value|
+              unnormalized_attributes[key] = REXML::Text::unnormalize(value)
+            end
+          elsif attributes.kind_of? Array
+            unnormalized_attributes = []
+            attributes.each do |value|
+              unnormalized_attributes << [value[0], REXML::Text::unnormalize(value[1])]
+            end
+          end
+          
+          e.add_attributes unnormalized_attributes
           @current = @current.nil? ? e : @current.add_element(e)
 
           # Handling <stream:stream> not only when it is being

--- a/test/tc_streamparser.rb
+++ b/test/tc_streamparser.rb
@@ -101,9 +101,9 @@ class StreamParserTest < Test::Unit::TestCase
   end
 
   def test_entity_escaping3
-    parse_simple_helper( "<a href='htpp://google.com?p=1&amp;p=2'>text</a>" ) do |desired|
+    parse_simple_helper( "<a href='http://google.com?p=1&amp;p=2'>text</a>" ) do |desired|
       assert_equal "text", @listener.received.text
-      assert_equal "<a href='htpp://google.com?p=1&amp;p=2'>text</a>", @listener.received.to_s
+      assert_equal "<a href='http://google.com?p=1&amp;p=2'>text</a>", @listener.received.to_s
     end
   end
 

--- a/test/tc_streamparser.rb
+++ b/test/tc_streamparser.rb
@@ -100,6 +100,13 @@ class StreamParserTest < Test::Unit::TestCase
     end
   end
 
+  def test_entity_escaping3
+    parse_simple_helper( "<a href='htpp://google.com?p=1&amp;p=2'>text</a>" ) do |desired|
+      assert_equal "text", @listener.received.text
+      assert_equal "<a href='htpp://google.com?p=1&amp;p=2'>text</a>", @listener.received.to_s
+    end
+  end
+
 =begin
   ##
   # FIXME:


### PR DESCRIPTION
Please see this ticket for more details: http://github.com/ln/xmpp4r/issues#issue/13

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/lnussbaum/xmpp4r/14)

<!-- Reviewable:end -->
