### PR TITLE
Allow inheriting and overload methods in SimpleMUCClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ rdoc/*
 tools/*.png
 *~
 *#
+.DS_Store


### PR DESCRIPTION
Instead of having to define all the methods as blocks - could be done better, but this code ensures nothing would break. This commit would allow code that looks like this:

class ChatBot < Jabber::MUC::SimpleMUCClient
  def on_message(time, nick, text)
    # do stuff
  end
end
