### PR TITLE
Fixed file transfer file corruption on Windows

### DIFF
--- a/data/doc/xmpp4r/examples/advanced/recvfile.rb
+++ b/data/doc/xmpp4r/examples/advanced/recvfile.rb
@@ -58,7 +58,7 @@ ft.add_incoming_callback { |iq,file|
       puts "Waiting for stream configuration"
       if stream.accept
         puts "Stream established"
-        outfile = File.new(filename, (offset ? 'a' : 'w'))
+        outfile = File.new(filename, (offset ? 'ab' : 'wb'))
         while buf = stream.read(65536)
           outfile.write(buf)
           print '.'

--- a/lib/xmpp4r/bytestreams/helper/filetransfer.rb
+++ b/lib/xmpp4r/bytestreams/helper/filetransfer.rb
@@ -70,7 +70,7 @@ module Jabber
       include TransferSource
 
       def initialize(filename)
-        @file = File.new(filename)
+        @file = File.new(filename, "rb")
         @filename = filename
         @bytes_read = 0
         @length = nil


### PR DESCRIPTION
Current implementation could corrupt transferring files if either sender or receiver is on Windows. My patch fixes it.
