### PR TITLE
Fixes hang on facebook connection over windows

### DIFF
--- a/lib/xmpp4r/client.rb
+++ b/lib/xmpp4r/client.rb
@@ -172,6 +172,8 @@ module Jabber
 
       # Restart stream after SASL auth
       stop
+      while @parser_thread.alive? do
+      end
       start
       # And wait for features - again
       @features_sem.wait


### PR DESCRIPTION
It just waits while the @parser_thread is still alive to restart the connection.
