### PR TITLE
Replace $defout with $stdout

### DIFF
--- a/data/doc/xmpp4r/examples/basic/client.rb
+++ b/data/doc/xmpp4r/examples/basic/client.rb
@@ -19,7 +19,7 @@ class BasicClient
     # main loop
     while not quit do
       print "> "
-      $defout.flush
+      $stdout.flush
       line = gets
       quit = true if line.nil?
       if not quit

--- a/lib/xmpp4r/client.rb
+++ b/lib/xmpp4r/client.rb
@@ -239,7 +239,7 @@ module Jabber
         authset = Iq.new_authset(@jid, password)
       end
       send_with_id(authset)
-      $defout.flush
+      $stdout.flush
 
       true
     end


### PR DESCRIPTION
$defout have already disappeared from Ruby 1.9 or higher

Ref: #22
