### PR TITLE
Force SSLv3 because newer OpenSSL (1.0+) has TLSv1 issues

### DIFF
--- a/lib/xmpp4r/connection.rb
+++ b/lib/xmpp4r/connection.rb
@@ -145,6 +145,7 @@ module Jabber
 
         # Context/user set-able stuff
         ctx = OpenSSL::SSL::SSLContext.new
+        ctx.ssl_version = :SSLv3
         if @ssl_capath
           ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
           ctx.ca_path = @ssl_capath


### PR DESCRIPTION
Force SSLv3 because newer versions of OpenSSL (1.0+) often used in Ubuntu 12.04 have trouble auto-negotiating which version to use and the connection will hang or you will receive "SSL_connect:unknown state" errors.

More info here:

http://thinkinginsoftware.blogspot.com/2013/01/openssl-hanging-connected00000003.html
