### PR TITLE
Made the name in the help text match the file name

### DIFF
--- a/data/doc/xmpp4r/examples/basic/echo.rb
+++ b/data/doc/xmpp4r/examples/basic/echo.rb
@@ -9,7 +9,7 @@ include Jabber
 
 # settings
 if ARGV.length != 2
-  puts "Run with ./echo_thread.rb user@server/resource password"
+  puts "Run with ./echo.rb user@server/resource password"
   exit 1
 end
 myJID = JID.new(ARGV[0])


### PR DESCRIPTION
The name in the help was echo_thread.rb rather than just echo.rb
